### PR TITLE
FHG-3216 fix security issue

### DIFF
--- a/src/FamilyHubs.RequestForSupport.Web/StartupExtensions.cs
+++ b/src/FamilyHubs.RequestForSupport.Web/StartupExtensions.cs
@@ -57,7 +57,7 @@ public static class StartupExtensions
     {
         services.AddSecuredTypedHttpClient<IReferralClientService, ReferralClientService>((serviceProvider, httpClient) =>
         {
-            httpClient.BaseAddress = new Uri(configuration.GetValue<string>("ReferralUrl")!);
+            httpClient.BaseAddress = new Uri(configuration.GetValue<string>("ReferralApiUrl")!);
         });
     }
 

--- a/src/FamilyHubs.RequestForSupport.Web/VcsDashboard/VcsDashboardRow.cs
+++ b/src/FamilyHubs.RequestForSupport.Web/VcsDashboard/VcsDashboardRow.cs
@@ -1,5 +1,6 @@
 ﻿using FamilyHubs.ReferralService.Shared.Dto;
 using FamilyHubs.SharedKernel.Razor.Dashboard;
+using System.Web;
 
 namespace FamilyHubs.RequestForSupport.Web.VcsDashboard;
 
@@ -17,7 +18,7 @@ public class VcsDashboardRow : IRow<ReferralDto>
         get
         {
             yield return new Cell(
-                $"<a href=\"/VcsRequestForSupport/ConnectDetails?id={Item.Id}\" class=\"govuk-!-margin-right-1\">{Item.RecipientDto.Name}</a>");
+                $"<a href=\"/VcsRequestForSupport/ConnectDetails?id={Item.Id}\" class=\"govuk-!-margin-right-1\">{HttpUtility.HtmlEncode(Item.RecipientDto.Name)}</a>");
             yield return new Cell(Item.Created?.ToString("dd-MMM-yyyy") ?? "");
             yield return new Cell(Item.Id.ToString("X4"));
             yield return new Cell(null, "_ConnectionStatus");

--- a/src/FamilyHubs.RequestForSupport.Web/appsettings.json
+++ b/src/FamilyHubs.RequestForSupport.Web/appsettings.json
@@ -1,7 +1,7 @@
 {
   "LogLevel": "Verbose",
   "AllowedHosts": "*",
-  "ReferralUrl": "https://localhost:7192/",
+  "ReferralApiUrl": "https://localhost:7192/",
   "APPINSIGHTS_INSTRUMENTATIONKEY": "",
   "APPINSIGHTS_CONNECTION_STRING": "",
   "GovUkOidcConfiguration": {

--- a/src/FamilyHubs.RequestForSupport.Web/appsettings.json
+++ b/src/FamilyHubs.RequestForSupport.Web/appsettings.json
@@ -19,7 +19,7 @@
     "ExpiryInMinutes": 15,
     "BearerTokenSigningKey": "",
     "StubAuthentication": {
-      "UseStubAuthentication": true,
+      "UseStubAuthentication": false,
       "UseStubClaims": true
     }
   },


### PR DESCRIPTION
Html encode the recipients name, as it gets output as raw html.

Without this fix, the user could inject Html into their own page.

Tested with the user entering a closing anchor tag...

![image](https://github.com/DFE-Digital/fh-referral-dashboard-ui/assets/12608907/6a7ac42c-2ace-445c-969f-41ce9db04dcc)
