### PR TITLE
Only show referrer phone section if referrer is contactable by phone

### DIFF
--- a/src/FamilyHubs.RequestForSupport.Web/Pages/Shared/_ProfessionalContactDetails.cshtml
+++ b/src/FamilyHubs.RequestForSupport.Web/Pages/Shared/_ProfessionalContactDetails.cshtml
@@ -25,14 +25,17 @@
                     <a href="mailto:@(Model.ReferralUserAccountDto.EmailAddress)">@Model.ReferralUserAccountDto.EmailAddress</a>
                 </dd>
             </div>
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                    Phone
-                </dt>
-                <dd class="govuk-summary-list__value">
-                    <a href="tel:@(Model.ReferrerTelephone)">@Model.ReferrerTelephone</a>
-                </dd>
-            </div>
+            @if (!string.IsNullOrEmpty(Model.ReferrerTelephone))
+            {
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                        Phone
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                        <a href="tel:@(Model.ReferrerTelephone)">@Model.ReferrerTelephone</a>
+                    </dd>
+                </div>
+            }
         </dl>
     </div>
 </div>


### PR DESCRIPTION
Don't show the referrer's phone row on the details page, if the referrer indicated they were only to be contacted by email.